### PR TITLE
Improve handling of missing data in domain info outputs

### DIFF
--- a/domainrecon/cert_lookup.py
+++ b/domainrecon/cert_lookup.py
@@ -52,7 +52,17 @@ async def get_cert_subdomains(domain):
                 ip = a_records[0].to_text()
                 ip, asn, org = await resolve_asn(ip)
                 https_ok, status, server, powered_by, tech = await inspect_https_site(sub)
-                table.add_row(sub, ip, asn or "-",  org or "-",  "✅" if https_ok else "❌", str(status), server or "-", powered_by or "-", tech or "-")
+                table.add_row(
+                    sub,
+                    ip,
+                    asn or "-",
+                    org or "-",
+                    "✅" if https_ok else "❌",
+                    str(status) if status is not None else "-",
+                    server or "-",
+                    powered_by or "-",
+                    tech or "-",
+                )
             except Exception as e:
                 table.add_row(sub, "-", "-", "-", "-", "-", "-", "-", f"SSL fel: {e}")
 

--- a/domainrecon/dns_lookup.py
+++ b/domainrecon/dns_lookup.py
@@ -23,7 +23,7 @@ async def get_dns_info(domain):
         for r in a_records:
             ip = r.to_text()
             ip, asn, org = await resolve_asn(ip)
-            print(f"  {ip} (ASN: {asn}, Org: {org})")
+            print(f"  {ip} (ASN: {asn or '-'}, Org: {org or '-'})")
     except Exception as e:
         print(f"[red]No A records found:[/red] {e}")
 
@@ -39,7 +39,7 @@ async def get_dns_info(domain):
                 if mx_a_records:
                     ip = mx_a_records[0].to_text()
                     ip, asn, org = await resolve_asn(ip)
-                    print(f"    {ip} (ASN: {asn}, Org: {org})")
+                    print(f"    {ip} (ASN: {asn or '-'}, Org: {org or '-'})")
             except Exception as e:
                 print(f"    [red]Could not resolve A record for {mx_host}:[/red] {e}")
     except Exception as e:


### PR DESCRIPTION
## Summary
- Display '-' instead of `None` when ASN or organization cannot be resolved in DNS results
- Handle missing HTTP status codes in certificate enumeration to avoid showing `'None'`

## Testing
- `python -m pytest`
- `python -m domainrecon example.com --dns`


------
https://chatgpt.com/codex/tasks/task_e_68a87130112c832da704c80de8eb41d6